### PR TITLE
Expose dev server on all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ sudo bash install.sh
 ```
 
 The script will install Node.js 18, PM2, and FreePBX/Asterisk (if missing), then fetch the UI
-dependencies and start the development server under PM2 on port `5173`.
-After it completes, visit `http://<server-ip>:5173` in your browser.
+dependencies and start the development server under PM2 on port `5137`.
+After it completes, visit `http://<server-ip>:5137` in your browser.
 
 ## Development
 
@@ -26,7 +26,7 @@ After it completes, visit `http://<server-ip>:5173` in your browser.
 npm install
 npm run dev
 ```
-This starts Vite's dev server on <http://localhost:5173>. Tailwind is loaded via CDN so no extra build steps are required.
+This starts Vite's dev server on `http://0.0.0.0:5137`, making it accessible from other machines at `http://<server-ip>:5137`. Tailwind is loaded via CDN so no extra build steps are required.
 
 ### Build for production
 ```bash

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5137,
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server to listen on 0.0.0.0 port 5137
- document new port and host in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a466ed43f4832dbc5f538d262e48ff